### PR TITLE
Use console for unhandled errors instead of alert

### DIFF
--- a/main.js
+++ b/main.js
@@ -1414,7 +1414,7 @@ function apiErrorHandler(msg){
 
 function ajaxErrorHandler(event, jqXHR, ajaxSettings, thrownError){
   // TODO
-  alert('ajaxErrorHandler' + thrownError);
+  console.error('ajaxErrorHandler error: ' + thrownError);
 }
 
 /* to make a logout call */


### PR DESCRIPTION
This came up for me today when refreshing (an AJAX request hadn't finished, it seems).  I thought it would be better to just log the errors than interrupt the user -- at least for now.

Thanks for making this project!  It's quite nice.

Ben
