### PR TITLE
Configurable default limit on number of articles shown

### DIFF
--- a/conf.js-dist
+++ b/conf.js-dist
@@ -9,3 +9,7 @@ window.apiPath="/tt-rss/";
 
 /* relative URL from the root to access this webapp */
 window.webappPath="/ttrss-mobile/";
+
+/* Default number of articles to load */
+window.limit=10
+

--- a/main.js
+++ b/main.js
@@ -300,7 +300,7 @@ function defineModels(){
     }, //sync
 
     defaults: {
-      articlesNumber: 10
+      articlesNumber: ((window.limit > 0) && (window.limit <= 60)) ? window.limit : 10
     },
 
     validate: function(attrs, options){


### PR DESCRIPTION
Having a server-side configurable default limit on the number of articles shown is especially useful when browsers do not support localStorage e.g. Dolphin on my iPodTouch.

As simple as the patch is, imho it does the right thing:
- Server-side default value that can be overridden by the user;
- If localStorage works, the user value will be used from then on.
