### PR TITLE
Load both jQuery and jQuery Mobile over SSL to avoid HSTS problems

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="initial-scale=1">
   <meta charset="UTF-8">
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <link rel="stylesheet" href="http://code.jquery.com/mobile/1.3.0/jquery.mobile-1.3.0.min.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jquery-mobile/1.3.0/jquery.mobile.min.css" />
   <link rel="stylesheet" href="main.css">
-  <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.0.0/backbone-min.js"></script>
   <script src="conf.js"></script>
   <script src="main.js"></script>
-  <script src="http://code.jquery.com/mobile/1.3.0/jquery.mobile-1.3.0.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-mobile/1.3.0/jquery.mobile.min.js"></script>
   <!-- iPhone -->
   <link rel="apple-touch-icon"
         href="touch-icon-iphone.png" />


### PR DESCRIPTION
My pull request at cdnjs for jQuery Mobile 1.3.0 was accepted: https://github.com/cdnjs/cdnjs/pull/1126. Fixes https://github.com/mboinet/ttrss-mobile/issues/28.
