### PR TITLE
Small css tweak to wrap the article title

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -59,3 +59,12 @@ div#read div[data-role=content]>div.main pre {
 {
   font-weight: normal;
 }
+
+.ui-li-heading {
+    font-size: 14px;
+    white-space: normal;
+}
+
+.ui-li-desc {
+    font-size: 10px;
+}


### PR DESCRIPTION
Small tweak make the article title text wrap to the next line rather than being cut off.

Before:
![img_3472](https://f.cloud.github.com/assets/858414/449082/849a0736-b267-11e2-8c56-330885bafbf2.png)

After:
![img_3471](https://f.cloud.github.com/assets/858414/449083/883c32c4-b267-11e2-88f3-3cf37f41851d.png)
